### PR TITLE
Add icon and readme to Metalama.Documentation.QuickStart package (#251)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     </PropertyGroup>
 
     <Import Project="eng\Versions.props"/>
+    <Import Project="eng\Packaging.props"/>
     <Import Sdk="PostSharp.Engineering.Sdk" Project="BuildOptions.props" Condition="Exists('global.json')"/>
     <Import Sdk="PostSharp.Engineering.Sdk" Project="SourceLink.props" Condition="Exists('global.json')"/>
 


### PR DESCRIPTION
Closes metalama/Metalama.Documentation#251

## Summary

- Import `eng/Packaging.props` from `Directory.Build.props` so the PostSharp.Engineering.Sdk `MetalamaBranding.props` is applied to packable projects.
- This adds `metalama.png` (PackageIcon) and `LICENSE.md` to the `Metalama.Documentation.QuickStart` NuGet package. The package already packed `README.pkg.md`.

Per @gfraiteur's guidance on the issue, the same icon is used as other Metalama packages (provided by PostSharp.Engineering.Sdk). `eng/Packaging.props` already conditionally imports `MetalamaBranding.props` — this change makes that file actually be picked up.

## Verification

Built with `Build.ps1 build`. The produced `Metalama.Documentation.QuickStart.*.nupkg` now contains `metalama.png`, `LICENSE.md`, and `README.pkg.md`, and the nuspec declares `<icon>metalama.png</icon>` and `<readme>README.pkg.md</readme>`. Only `QuickStart` is packable in this repo so no other package content is affected.

## Checklist

- [x] Phase 1: Understand issue
- [x] Phase 2: Topic branch
- [x] Phase 3: Fix implemented
- [x] Phase 4: Build succeeded, package verified
- [ ] Phase 5: Finalize

— Claude for @PostSharpAgent